### PR TITLE
Fixed #7187. Removing reference ...

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -62,7 +62,6 @@ BaselineOfBasicTools >> baseline: spec [
 		
 		spec package: 'Tool-ProcessBrowser'.
 		spec package: 'Tool-Profilers'.
-		spec package: 'Tool-SystemReporter'.
 		spec package: 'NECompletion'.
 		spec package: 'NECompletion-Morphic'.
 		spec package: 'NECompletion-Preferences'.


### PR DESCRIPTION
... to Tool-SystemReporter from BaselineOfBasicTools